### PR TITLE
Add favicon assets and adjust Vite base path

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,13 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <!-- Favicon: 明示指定で /favicon.ico の自動取得を抑止して404を回避 -->
+    <!-- GitHub Pages (memotyou_public) に合わせ相対パスにしています -->
+    <link rel="icon" href="./favicon.svg" type="image/svg+xml">
+    <!-- （必要なら）PNGの保険。用意しないならこの行は削除OK -->
+    <!-- <link rel="alternate icon" href="./favicon.png" type="image/png"> -->
+
+    <!-- 以降、既存のタイトルやメタ等 -->
     <title>簡単メモ帳</title>
     <link rel="stylesheet" href="style.css">
 </head>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,12 @@
+<!-- シンプルで軽量なSVGファビコン（16x16） -->
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="16" y2="16" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-opacity="0.9"/>
+      <stop offset="1" stop-opacity="0.9"/>
+    </linearGradient>
+  </defs>
+  <rect x="0" y="0" width="16" height="16" fill="url(#g)"/>
+  <path d="M8 2.5l1.3 2.6 2.9.4-2.1 2 0.5 2.9L8 9.2 5.4 10.4l0.5-2.9-2.1-2 2.9-.4L8 2.5z"
+        fill="#fff" fill-opacity="0.95"/>
+</svg>

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,5 +1,6 @@
-import { defineConfig } from 'vite'
-
-export default defineConfig({
-  base: '/memotyou_public/',   // 公開用リポ名に合わせる
-})
+// TS ではなく JS 構成の場合はこちらを使用
+// 片方（ts/js）だけ残してください
+export default {
+  // GitHub Pages のプロジェクトページ公開に合わせた base 設定
+  base: '/memotyou_public/',
+};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+// GitHub Pages のプロジェクトページ公開に合わせた base 設定
+// 公開先が https://<user>.github.io/memotyou_public/ の場合
+export default defineConfig({
+  base: '/memotyou_public/',
+});


### PR DESCRIPTION
## Summary
- add explicit favicon links to the HTML head and supply a favicon.svg asset
- provide Vite configuration files with the GitHub Pages base path

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cdf694109083248fcf1d1ec749b8f4