### PR TITLE
Add theme tokens and sync dark mode handling

### DIFF
--- a/script.js
+++ b/script.js
@@ -98,17 +98,15 @@ class SimpleNotepad {
         const defaultTheme = document.body.getAttribute('data-theme') || 'light';
         const theme = readStoredTheme(defaultTheme);
 
-        document.body.setAttribute('data-theme', theme);
-        this.updateThemeToggleLabel(theme);
+        this.applyTheme(theme);
     }
 
     toggleTheme() {
         const currentTheme = document.body.getAttribute('data-theme') === 'dark' ? 'dark' : 'light';
         const nextTheme = currentTheme === 'light' ? 'dark' : 'light';
 
-        document.body.setAttribute('data-theme', nextTheme);
+        this.applyTheme(nextTheme);
         writeStoredTheme(nextTheme);
-        this.updateThemeToggleLabel(nextTheme);
     }
 
     updateThemeToggleLabel(theme) {
@@ -117,6 +115,12 @@ class SimpleNotepad {
         const isDark = theme === 'dark';
         this.themeToggle.textContent = isDark ? 'ライトテーマ' : 'ダークテーマ';
         this.themeToggle.setAttribute('aria-pressed', String(isDark));
+    }
+
+    applyTheme(theme) {
+        document.body.setAttribute('data-theme', theme);
+        document.documentElement.classList.toggle('dark', theme === 'dark');
+        this.updateThemeToggleLabel(theme);
     }
 
     notifyStorageIssue(message, { force = false } = {}) {

--- a/style.css
+++ b/style.css
@@ -4,7 +4,14 @@
     box-sizing: border-box;
 }
 
+/* === Theme tokens === */
 :root {
+    --bg: #ffffff;
+    --fg: #111111;
+    --muted: #666666;
+    --link: #0b66c3;
+    color-scheme: light;
+
     --bg-color: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
     --text-color: #2c3e50;
     --container-bg-color: #ffffff;
@@ -21,6 +28,25 @@
     --muted-text-color: #7f8c8d;
     --saved-text-color: #27ae60;
     --unsaved-text-color: #e74c3c;
+}
+
+html.dark {
+    --bg: #0b0b0f;
+    --fg: #e9e9ee;
+    --muted: #a0a3ab;
+    --link: #86b7ff;
+    color-scheme: dark;
+}
+
+html,
+body {
+    background: var(--bg);
+    color: var(--fg);
+    transition: background 0.15s, color 0.15s;
+}
+
+a {
+    color: var(--link);
 }
 
 body[data-theme="dark"] {


### PR DESCRIPTION
## Summary
- introduce global theme tokens for base document colors and links
- toggle the `dark` class on `<html>` to align with the new CSS tokens while keeping existing body-based theming

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cdfa2bed648324af2af5ac46df6edb