### PR TITLE
Adjust asset paths and improve theme toggle handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
 <head>
     <meta charset="UTF-8">
@@ -11,7 +11,8 @@
 
     <!-- 以降、既存のタイトルやメタ等 -->
     <title>簡単メモ帳</title>
-    <link rel="stylesheet" href="style.css">
+    <!-- GH Pagesでの404回避のため相対パスに統一 -->
+    <link rel="stylesheet" href="./style.css">
 </head>
 <body data-theme="light">
     <div class="container">
@@ -37,7 +38,7 @@
             </div>
         </footer>
     </div>
-    
-    <script src="script.js"></script>
+    <!-- Viteがバンドル対象として拾えるように type="module" を付与 -->
+    <script type="module" src="./script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,4 +1,4 @@
-const THEME_STORAGE_KEY = 'notepad_theme';
+const THEME_STORAGE_KEY = 'theme';
 const NOTEPAD_CONTENT_KEY = 'notepad_content';
 const NOTEPAD_TIMESTAMP_KEY = 'notepad_timestamp';
 
@@ -95,14 +95,16 @@ class SimpleNotepad {
     }
 
     initTheme() {
-        const defaultTheme = document.body.getAttribute('data-theme') || 'light';
-        const theme = readStoredTheme(defaultTheme);
+        const storedTheme = readStoredTheme(null);
+        const prefersDark = typeof window.matchMedia === 'function'
+            && window.matchMedia('(prefers-color-scheme: dark)').matches;
+        const initialTheme = storedTheme || (prefersDark ? 'dark' : 'light');
 
-        this.applyTheme(theme);
+        this.applyTheme(initialTheme);
     }
 
     toggleTheme() {
-        const currentTheme = document.body.getAttribute('data-theme') === 'dark' ? 'dark' : 'light';
+        const currentTheme = document.documentElement.classList.contains('dark') ? 'dark' : 'light';
         const nextTheme = currentTheme === 'light' ? 'dark' : 'light';
 
         this.applyTheme(nextTheme);
@@ -262,6 +264,7 @@ class SimpleNotepad {
 }
 
 // アプリケーション初期化
+// DOM構築後に配線（type="module" なら本来 defer 相当ですが念のため）
 document.addEventListener('DOMContentLoaded', () => {
     new SimpleNotepad();
 });

--- a/style.css
+++ b/style.css
@@ -5,11 +5,11 @@
 }
 
 /* === Theme tokens === */
-:root {
-    --bg: #ffffff;
-    --fg: #111111;
-    --muted: #666666;
-    --link: #0b66c3;
+:root{
+    --bg:#ffffff;
+    --fg:#111111;
+    --muted:#666666;
+    --link:#0b66c3;
     color-scheme: light;
 
     --bg-color: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
@@ -30,26 +30,13 @@
     --unsaved-text-color: #e74c3c;
 }
 
-html.dark {
-    --bg: #0b0b0f;
-    --fg: #e9e9ee;
-    --muted: #a0a3ab;
-    --link: #86b7ff;
+html.dark{
+    --bg:#0b0b0f;
+    --fg:#e9e9ee;
+    --muted:#a0a3ab;
+    --link:#86b7ff;
     color-scheme: dark;
-}
 
-html,
-body {
-    background: var(--bg);
-    color: var(--fg);
-    transition: background 0.15s, color 0.15s;
-}
-
-a {
-    color: var(--link);
-}
-
-body[data-theme="dark"] {
     --bg-color: linear-gradient(135deg, #141e30 0%, #243b55 100%);
     --text-color: #f5f7fa;
     --container-bg-color: #1f2933;
@@ -66,6 +53,17 @@ body[data-theme="dark"] {
     --muted-text-color: #94a3b8;
     --saved-text-color: #2dd4bf;
     --unsaved-text-color: #f87171;
+}
+
+html,
+body {
+    background: var(--bg);
+    color: var(--fg);
+    transition: background 0.15s, color 0.15s;
+}
+
+a {
+    color: var(--link);
 }
 
 body {


### PR DESCRIPTION
## Summary
- switch stylesheet and script references to relative paths and mark the script as a module so Vite can bundle it correctly
- expand the theme token definitions to the html root and apply them across light and dark modes
- initialize the theme from storage or system preference, toggle the html class, and persist button state on DOM ready

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cdfcb9a59c83249c5b769dc90ea31c